### PR TITLE
README 병합 충돌 해결

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Visionix Device Webserver
+
+이 프로젝트는 Visionix 디바이스용 간단한 웹서버입니다.
+
+## 🛠️ 설치 방법
+```bash
+./install.sh
+```
+
+## 🚀 실행 방법
+```bash
+./run.sh
+```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# 가상환경 생성 및 활성화
+python3 -m venv venv
+source venv/bin/activate
+
+# 의존성 설치
+pip install -r requirements.txt
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# 가상환경 활성화 후 애플리케이션 실행
+source venv/bin/activate
+python app.py


### PR DESCRIPTION
## 변경 사항
- README에 설치 및 실행 방법을 모두 포함하도록 병합했습니다.
- 누락되었던 `install.sh`, `run.sh` 스크립트를 복원했습니다.

## 테스트 결과
- `pytest -q` 실행: 테스트 파일이 없어 아무 것도 실행되지 않았습니다.


------
https://chatgpt.com/codex/tasks/task_e_6864a7a1b7e48326bde8354d63e922a1